### PR TITLE
Fix for WebView2Wpf init

### DIFF
--- a/Version.json
+++ b/Version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "publicReleaseRefSpec": [
         "^refs/heads/master$",
         "^refs/heads/main$"

--- a/src/CrissCross.WPF.UI.CC_Nav.Test/MainWindow.xaml.cs
+++ b/src/CrissCross.WPF.UI.CC_Nav.Test/MainWindow.xaml.cs
@@ -22,7 +22,7 @@ namespace CrissCross.WPF.UI.CC_Nav.Test
             this.WhenActivated(d =>
             {
                 NavBack.Command = ReactiveCommand.Create(() => this.NavigateBack(), this.CanNavigateBack()).DisposeWith(d);
-                this.NavigateToView<MainViewModel>();
+                this.NavigateToView(typeof(MainViewModel));
             });
         }
     }

--- a/src/CrissCross.WPF.UI/Controls/ProgressBar/ProgressBar.xaml
+++ b/src/CrissCross.WPF.UI/Controls/ProgressBar/ProgressBar.xaml
@@ -19,6 +19,26 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ProgressBar}">
                     <Grid Name="TemplateRoot" SnapsToDevicePixels="True">
+                        <Grid.Style>
+                            <Style TargetType="Grid">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Orientation}" Value="Horizontal">
+                                        <Setter Property="LayoutTransform">
+                                            <Setter.Value>
+                                                <RotateTransform Angle="0" />
+                                            </Setter.Value>
+                                        </Setter>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Orientation}" Value="Vertical">
+                                        <Setter Property="LayoutTransform">
+                                            <Setter.Value>
+                                                <RotateTransform Angle="-90" />
+                                            </Setter.Value>
+                                        </Setter>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Style>
                         <Border
                             Margin="1,1,1,1"
                             Background="{TemplateBinding Background}"
@@ -42,6 +62,26 @@
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ProgressBar}">
                             <Grid Name="TemplateRoot">
+                                <Grid.Style>
+                                    <Style TargetType="Grid">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Orientation}" Value="Horizontal">
+                                                <Setter Property="LayoutTransform">
+                                                    <Setter.Value>
+                                                        <RotateTransform Angle="0" />
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Orientation}" Value="Vertical">
+                                                <Setter Property="LayoutTransform">
+                                                    <Setter.Value>
+                                                        <RotateTransform Angle="-90" />
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Grid.Style>
                                 <Border
                                     Margin="1,1,1,1"
                                     Background="{DynamicResource ProgressBarIndeterminateBackground}"

--- a/src/CrissCross.WPF.WebView2.Test/MainWindow.xaml
+++ b/src/CrissCross.WPF.WebView2.Test/MainWindow.xaml
@@ -11,7 +11,10 @@
     Height="450"
     mc:Ignorable="d">
     <Grid>
-        <rxnav:WebView2Wpf x:Name="WebView2Wpf" Source="https://www.aicsolutions.com">
+        <rxnav:WebView2Wpf
+            x:Name="WebView2Wpf"
+            AutoDispose="True"
+            Source="https://www.aicsolutions.com">
             <StackPanel HorizontalAlignment="Left">
                 <TextBlock
                     x:Name="Greeting"

--- a/src/CrissCross.WPF.WebView2.Test/MainWindow.xaml.cs
+++ b/src/CrissCross.WPF.WebView2.Test/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
 using System.Windows;
 
 namespace CrissCross.WPF.WebView2.Test
@@ -18,6 +19,16 @@ namespace CrissCross.WPF.WebView2.Test
         public MainWindow()
         {
             InitializeComponent();
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Windows.Window.Closing" /> event.
+        /// </summary>
+        /// <param name="e">A <see cref="T:System.ComponentModel.CancelEventArgs" /> that contains the event data.</param>
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            ////WebView2Wpf.Dispose();
+            base.OnClosing(e);
         }
 
         private void WindowsXp_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Fix for #86 
Update WebView
Add Events
Add AutoDispose property = true - Set to false to stop the control automatically Disposing when Unloaded.
Add EnsureCoreWebView2Async()

Update CrissCross NavigateToView to add a non-generics navigation option.