### PR TITLE
Make UiApplication thread-static and update deps

### DIFF
--- a/src/CrissCross.WPF.UI/UiApplication.cs
+++ b/src/CrissCross.WPF.UI/UiApplication.cs
@@ -14,6 +14,7 @@ namespace CrissCross.WPF.UI;
 /// </remarks>
 public class UiApplication
 {
+    [ThreadStatic]
     private static UiApplication? _uiApplication;
     private readonly Application? _application;
     private ResourceDictionary? _resources;

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AvaloniaVersion>11.3.12</AvaloniaVersion>
+    <AvaloniaVersion>11.3.13</AvaloniaVersion>
     <SplatVersion>19.2.1</SplatVersion>
-    <ReactiveUIVersion>23.1.8</ReactiveUIVersion>
+    <ReactiveUIVersion>23.2.1</ReactiveUIVersion>
     <WebViewVersion>1.0.3856.49</WebViewVersion>
   </PropertyGroup>
 
@@ -31,14 +31,14 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.41" Condition="$(TargetFramework.StartsWith('net10'))" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.51" Condition="$(TargetFramework.StartsWith('net10'))" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.120" Condition="!$(TargetFramework.StartsWith('net10'))" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.41" Condition="$(TargetFramework.StartsWith('net10'))" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.51" Condition="$(TargetFramework.StartsWith('net10'))" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.120" Condition="!$(TargetFramework.StartsWith('net10'))" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="$(WebViewVersion)" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.142" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.5" />
-    <PackageVersion Include="Polyfill" Version="9.18.0" />
+    <PackageVersion Include="Polyfill" Version="10.1.1" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
 
@@ -50,22 +50,22 @@
     <PackageVersion Include="AngleSharp" Version="1.4.0" />
     <PackageVersion Include="AppBarButton.WPF" Version="1.0.2" />
     <PackageVersion Include="BBCode.WPF" Version="1.0.2" />
-    <PackageVersion Include="CP.Extensions.Hosting.ReactiveUI.Wpf" Version="3.0.6" />
-    <PackageVersion Include="CP.Extensions.Hosting.ReactiveUI.Avalonia" Version="3.0.6" />
-    <PackageVersion Include="CP.Extensions.Hosting.MainUIThread" Version="3.0.6" />
+    <PackageVersion Include="CP.Extensions.Hosting.ReactiveUI.Wpf" Version="3.0.9" />
+    <PackageVersion Include="CP.Extensions.Hosting.ReactiveUI.Avalonia" Version="3.0.9" />
+    <PackageVersion Include="CP.Extensions.Hosting.MainUIThread" Version="3.0.9" />
     <PackageVersion Include="CP.Xaml.Converters" Version="1.1.3" />
-    <PackageVersion Include="Markdig" Version="1.1.1" />
+    <PackageVersion Include="Markdig" Version="1.1.2" />
     <PackageVersion Include="ReactiveList" Version="4.0.16" />
-    <PackageVersion Include="ScottPlot.WPF" Version="5.1.57" />
+    <PackageVersion Include="ScottPlot.WPF" Version="5.1.58" />
 
     <!-- Polyfill for .NET Framework -->
     <PackageVersion Include="Polyfill" Version="9.22.0" />
 
     <!-- Testing Packages -->
-    <PackageVersion Include="TUnit" Version="1.19.57" Condition="$(IsTestProject)" />
-    <PackageVersion Include="Verify.TUnit" Version="31.13.2" Condition="$(IsTestProject)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" Condition="$(IsTestProject)" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" Condition="$(IsTestProject)" />
+    <PackageVersion Include="TUnit" Version="1.30.0" Condition="$(IsTestProject)" />
+    <PackageVersion Include="Verify.TUnit" Version="31.15.0" Condition="$(IsTestProject)" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" Condition="$(IsTestProject)" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" Condition="$(IsTestProject)" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" Condition="$(IsTestProject)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" Condition="!$(IsTestProject)" />
 
@@ -77,8 +77,8 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
 
     <!-- Android Specific -->
-    <PackageVersion Include="Xamarin.AndroidX.Compose.Runtime.Annotation" Version="1.10.0.1" />
-    <PackageVersion Include="Xamarin.AndroidX.Compose.Runtime.Annotation.Android" Version="1.10.0.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Compose.Runtime.Annotation" Version="1.10.4.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Compose.Runtime.Annotation.Android" Version="1.10.4.1" />
     <PackageVersion Include="Xamarin.AndroidX.Compose.Runtime.Annotation.Jvm" Version="1.10.4.1" />
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0.2" />
   </ItemGroup>

--- a/src/Tests/CrissCross.Tests/CrissCross.Tests.csproj
+++ b/src/Tests/CrissCross.Tests/CrissCross.Tests.csproj
@@ -11,6 +11,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\CrissCross\CrissCross.csproj" />
+    <Using Include="TUnit.Core"/>
+    <Using Include="TUnit.Assertions"/>
+    <Using Include="TUnit.Assertions.Extensions"/>
   </ItemGroup>
 
 </Project>

--- a/src/Tests/CrissCross.Tests/NavigationEventArgsTests.cs
+++ b/src/Tests/CrissCross.Tests/NavigationEventArgsTests.cs
@@ -2,11 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using CrissCross;
 using ReactiveUI;
-using TUnit.Assertions;
-using TUnit.Assertions.Extensions;
-using TUnit.Core;
 
 namespace CrissCross.Tests;
 

--- a/src/Tests/CrissCross.Tests/RxObjectMixinsTests.cs
+++ b/src/Tests/CrissCross.Tests/RxObjectMixinsTests.cs
@@ -5,6 +5,7 @@
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using ReactiveUI;
+using ReactiveUI.Builder;
 using Splat;
 
 namespace CrissCross.Tests;
@@ -14,6 +15,9 @@ namespace CrissCross.Tests;
 /// </summary>
 public class RxObjectMixinsTests
 {
+    [Before(HookType.Class)]
+    public static void InitializeReactiveUI() => Locator.CurrentMutable.CreateReactiveUIBuilder().WithCoreServices().BuildApp();
+
     private class TestReactiveObject : ReactiveObject
     {
         private string? _testProperty;
@@ -47,6 +51,7 @@ public class RxObjectMixinsTests
         await Assert.That(signalReceived).IsTrue();
 
         subscription.Dispose();
+        testObject.Dispose();
     }
 
     [Test]
@@ -67,6 +72,7 @@ public class RxObjectMixinsTests
 
         // Assert
         await Assert.That(actionExecuted).IsTrue();
+        testObject.Dispose();
     }
 
     [Test]
@@ -84,6 +90,7 @@ public class RxObjectMixinsTests
         await Assert.That(disposable).IsAssignableTo<IDisposable>();
 
         disposable.Dispose();
+        testObject.Dispose();
     }
 
     [Test]
@@ -105,6 +112,7 @@ public class RxObjectMixinsTests
 
         // Assert - action should not execute after disposal
         await Assert.That(actionExecuted).IsFalse();
+        testObject.Dispose();
     }
 
     [Test]
@@ -129,6 +137,7 @@ public class RxObjectMixinsTests
         await Assert.That(observableList.Count).IsEqualTo(2);
 
         subscription.Dispose();
+        subject.Dispose();
     }
 
     [Test]
@@ -158,6 +167,7 @@ public class RxObjectMixinsTests
         await Assert.That(observableList.Count).IsEqualTo(2);
 
         subscription.Dispose();
+        subject.Dispose();
     }
 
     [Test]
@@ -182,6 +192,7 @@ public class RxObjectMixinsTests
         await Assert.That(result).IsTrue();
 
         subscription.Dispose();
+        subject.Dispose();
     }
 
     [Test]
@@ -206,6 +217,7 @@ public class RxObjectMixinsTests
         await Assert.That(result).IsFalse();
 
         subscription.Dispose();
+        subject.Dispose();
     }
 
     [Test]
@@ -235,6 +247,7 @@ public class RxObjectMixinsTests
         await Assert.That(result).IsTrue();
 
         subscription.Dispose();
+        subject.Dispose();
     }
 
     [Test]
@@ -254,6 +267,7 @@ public class RxObjectMixinsTests
         await Assert.That(receivedValue).IsFalse();
 
         subscription.Dispose();
+        subject.Dispose();
     }
 
     [Test]
@@ -274,5 +288,6 @@ public class RxObjectMixinsTests
         await Assert.That(observableList.Count).IsEqualTo(0);
 
         subscription.Dispose();
+        subject.Dispose();
     }
 }

--- a/src/Tests/CrissCross.Tests/RxObjectTests.cs
+++ b/src/Tests/CrissCross.Tests/RxObjectTests.cs
@@ -3,10 +3,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Reactive.Disposables;
-using CrissCross;
-using TUnit.Assertions;
-using TUnit.Assertions.Extensions;
-using TUnit.Core;
 
 namespace CrissCross.Tests;
 

--- a/src/Tests/CrissCross.Tests/ViewModelRoutedViewHostMixinsTests.cs
+++ b/src/Tests/CrissCross.Tests/ViewModelRoutedViewHostMixinsTests.cs
@@ -7,12 +7,8 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using CrissCross;
 using ReactiveUI;
 using Splat;
-using TUnit.Assertions;
-using TUnit.Assertions.Extensions;
-using TUnit.Core;
 
 namespace CrissCross.Tests;
 
@@ -164,7 +160,7 @@ public class ViewModelRoutedViewHostMixinsTests
         }
     }
 
-    [Before(Test)]
+    [Before(HookType.Test)]
     public async Task Setup()
     {
         // Note: We don't clear static dictionaries as it causes test isolation issues


### PR DESCRIPTION
Mark UiApplication._uiApplication with [ThreadStatic] to ensure per-thread instance. 
Bump multiple package versions in Directory.Packages.props (Avalonia, ReactiveUI, Maui packages, CP.Extensions, Polyfill, Markdig, ScottPlot, testing libraries, AndroidX, etc.). 
Update test project to include TUnit usings, add ReactiveUI.Builder initialization for tests, remove unused usings, dispose test objects/subjects after tests, and adjust Before attribute to use HookType.Test for proper test setup and isolation.