### PR TITLE
Fix Avalonia NavigationUserControl; Support numeric X-axis

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -13,10 +13,10 @@
 
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" />
-    <PackageReference Include="NuGet.Packaging" Version="7.3.1" />
+    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
     <PackageReference Include="Nuke.Common" Version="10.1.0" />
-    <PackageReference Include="CP.Nuke.BuildTools" Version="2.0.16" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="CP.Nuke.BuildTools" Version="3.0.2" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/reactive-wpf-plot-streams.md
+++ b/docs/reactive-wpf-plot-streams.md
@@ -5,7 +5,7 @@
 ## Minimal usage
 
 ```csharp
-var signalTicks = new Subject<(string? Name, IList<double>? Value, IList<double> DateTime, int Axis)>();
+var signalPoints = new Subject<(string? Name, IList<double>? Value, IList<double> X, int Axis)>();
 var scatterPoints = new Subject<(string? Name, IList<double>? X, IList<double> Y, int Axis)>();
 var loggerPoints = new Subject<(string? Name, IList<double>? Value, int Axis, int nMaxPoints)>();
 var streamerPoints = new Subject<(string? Name, IList<double>? Y, IList<double> X, int Axis)>();
@@ -13,7 +13,7 @@ var signalXyPoints = new Subject<(string? Name, IList<double>? Y, IList<double> 
 
 Chart.ReactivePlotSources =
 [
-    ReactivePlotSource.FromSignalTicks(signalTicks),
+    ReactivePlotSource.FromSignalPoints(signalPoints),
     ReactivePlotSource.FromScatterPoints(scatterPoints),
     ReactivePlotSource.FromDataLoggerPoints(loggerPoints),
     ReactivePlotSource.FromStreamerPoints(streamerPoints),
@@ -28,6 +28,7 @@ Each source emits one logical series. Series identity is derived from the emitte
 | Chart type | Factory | Update mode | X-axis kind |
 |---|---|---|---|
 | Signal | `ReactivePlotSource.FromSignalTicks(...)` | Append | Ticks |
+| Signal | `ReactivePlotSource.FromSignalPoints(...)` | Append | Numeric |
 | Scatter | `ReactivePlotSource.FromScatterPoints(...)` | Replace | Numeric |
 | DataLogger | `ReactivePlotSource.FromDataLoggerPoints(...)` | Append | Numeric ordinal |
 | Streamer | `ReactivePlotSource.FromStreamerPoints(...)` | Append | Numeric |
@@ -61,4 +62,4 @@ Use `UiScheduler` in tests or specialized hosts to control marshalling determini
 
 ## Example project
 
-The WPF plot example at `src/CrissCross.WPF.Plot.Test` demonstrates all five source factories through `MainViewModel.ReactivePlotSources`. It starts live demo subjects when the chart view model is attached and disposes the interval subscription with the view model.
+The WPF plot example at `src/CrissCross.WPF.Plot.Test` demonstrates all five chart types through `MainViewModel.ReactivePlotSources`. It uses one numeric X-axis scale for the live demo so all series render together, starts live demo subjects when the chart view model is attached, and disposes the interval subscription with the view model.

--- a/src/CrissCross.Avalonia/NavigationUserControl.cs
+++ b/src/CrissCross.Avalonia/NavigationUserControl.cs
@@ -32,15 +32,14 @@ public class NavigationUserControl : UserControl, ISetNavigation, IUseNavigation
     public static readonly StyledProperty<ViewModelRoutedViewHost?> NavigationFrameProperty =
         AvaloniaProperty.Register<NavigationUserControl, ViewModelRoutedViewHost?>(nameof(NavigationFrame));
 
+    private string? _navigationHostName;
+
     static NavigationUserControl() =>
         NavigationFrameProperty.Changed.Subscribe(static (e) =>
         {
             if (e.Sender is NavigationUserControl navigationWindow && e.NewValue.Value is ViewModelRoutedViewHost host)
             {
-                var hostName = ResolveNavigationHostName(navigationWindow, nameof(NavigationUserControl));
-
-                navigationWindow.Name = hostName;
-                navigationWindow.SetMainNavigationHost(host);
+                navigationWindow.ConfigureNavigationHost(host, nameof(NavigationUserControl));
             }
         });
 
@@ -77,14 +76,20 @@ public class NavigationUserControl : UserControl, ISetNavigation, IUseNavigation
         private set => SetValue(NavigationFrameProperty, value);
     }
 
+    /// <inheritdoc/>
+    string? ISetNavigation.Name => _navigationHostName ?? Name;
+
+    /// <inheritdoc/>
+    string? IUseNavigation.Name => _navigationHostName ?? Name;
+
     /// <summary>
     /// Called when the control finishes initialization.
     /// </summary>
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        var hostName = ResolveNavigationHostName(this, nameof(NavigationUserControl));
-        Name = hostName;
+        var hostName = ResolveNavigationHostName(nameof(NavigationUserControl));
+        _navigationHostName = hostName;
         NavigationFrame = new()
         {
             HorizontalAlignment = HorizontalAlignment.Stretch,
@@ -92,12 +97,6 @@ public class NavigationUserControl : UserControl, ISetNavigation, IUseNavigation
             HostName = hostName,
             NavigateBackIsEnabled = NavigateBackIsEnabled
         };
-
-        if (NavigationFrame is not null)
-        {
-            NavigationFrame.Name = hostName;
-            this.SetMainNavigationHost(NavigationFrame);
-        }
     }
 
     /// <summary>
@@ -120,13 +119,32 @@ public class NavigationUserControl : UserControl, ISetNavigation, IUseNavigation
         return base.RegisterContentPresenter(presenter);
     }
 
-    private static string ResolveNavigationHostName(NavigationUserControl navigationUserControl, string fallbackPrefix)
+    private void ConfigureNavigationHost(ViewModelRoutedViewHost host, string fallbackPrefix)
     {
-        if (!string.IsNullOrWhiteSpace(navigationUserControl.Name))
+        var hostName = ResolveNavigationHostName(fallbackPrefix);
+        _navigationHostName = hostName;
+        host.HostName = hostName;
+
+        if (string.IsNullOrWhiteSpace(host.Name))
         {
-            return navigationUserControl.Name!;
+            host.Name = hostName;
         }
 
-        return $"__crisscross_navhost_{fallbackPrefix}_{RuntimeHelpers.GetHashCode(navigationUserControl):X8}";
+        this.SetMainNavigationHost(host);
+    }
+
+    private string ResolveNavigationHostName(string fallbackPrefix)
+    {
+        if (!string.IsNullOrWhiteSpace(_navigationHostName))
+        {
+            return _navigationHostName!;
+        }
+
+        if (!string.IsNullOrWhiteSpace(Name))
+        {
+            return Name!;
+        }
+
+        return $"__crisscross_navhost_{fallbackPrefix}_{RuntimeHelpers.GetHashCode(this):X8}";
     }
 }

--- a/src/CrissCross.Avalonia/NavigationWindow.cs
+++ b/src/CrissCross.Avalonia/NavigationWindow.cs
@@ -38,15 +38,14 @@ public class NavigationWindow : Window, ISetNavigation, IUseNavigation, IActivat
     public static readonly StyledProperty<ViewModelRoutedViewHost?> NavigationFrameProperty =
         AvaloniaProperty.Register<NavigationWindow, ViewModelRoutedViewHost?>(nameof(NavigationFrame));
 
+    private string? _navigationHostName;
+
     static NavigationWindow() =>
         NavigationFrameProperty.Changed.Subscribe(static (e) =>
         {
             if (e.Sender is NavigationWindow navigationWindow && e.NewValue.Value is ViewModelRoutedViewHost host)
             {
-                var hostName = ResolveNavigationHostName(navigationWindow, nameof(NavigationWindow));
-                navigationWindow.Name = hostName;
-                host.Name = hostName;
-                navigationWindow.SetMainNavigationHost(host);
+                navigationWindow.ConfigureNavigationHost(host, nameof(NavigationWindow));
             }
         });
 
@@ -83,14 +82,20 @@ public class NavigationWindow : Window, ISetNavigation, IUseNavigation, IActivat
         private set => SetValue(NavigationFrameProperty, value);
     }
 
+    /// <inheritdoc/>
+    string? ISetNavigation.Name => _navigationHostName ?? Name;
+
+    /// <inheritdoc/>
+    string? IUseNavigation.Name => _navigationHostName ?? Name;
+
     /// <summary>
     /// Called when the control finishes initialization.
     /// </summary>
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        var hostName = ResolveNavigationHostName(this, nameof(NavigationWindow));
-        Name = hostName;
+        var hostName = ResolveNavigationHostName(nameof(NavigationWindow));
+        _navigationHostName = hostName;
         NavigationFrame = new()
         {
             HorizontalAlignment = HorizontalAlignment.Stretch,
@@ -98,12 +103,6 @@ public class NavigationWindow : Window, ISetNavigation, IUseNavigation, IActivat
             HostName = hostName,
             NavigateBackIsEnabled = NavigateBackIsEnabled
         };
-
-        if (NavigationFrame is not null)
-        {
-            NavigationFrame.Name = hostName;
-            this.SetMainNavigationHost(NavigationFrame);
-        }
     }
 
     /// <summary>
@@ -126,13 +125,32 @@ public class NavigationWindow : Window, ISetNavigation, IUseNavigation, IActivat
         return base.RegisterContentPresenter(presenter);
     }
 
-    private static string ResolveNavigationHostName(NavigationWindow navigationWindow, string fallbackPrefix)
+    private void ConfigureNavigationHost(ViewModelRoutedViewHost host, string fallbackPrefix)
     {
-        if (!string.IsNullOrWhiteSpace(navigationWindow.Name))
+        var hostName = ResolveNavigationHostName(fallbackPrefix);
+        _navigationHostName = hostName;
+        host.HostName = hostName;
+
+        if (string.IsNullOrWhiteSpace(host.Name))
         {
-            return navigationWindow.Name!;
+            host.Name = hostName;
         }
 
-        return $"__crisscross_navhost_{fallbackPrefix}_{RuntimeHelpers.GetHashCode(navigationWindow):X8}";
+        this.SetMainNavigationHost(host);
+    }
+
+    private string ResolveNavigationHostName(string fallbackPrefix)
+    {
+        if (!string.IsNullOrWhiteSpace(_navigationHostName))
+        {
+            return _navigationHostName!;
+        }
+
+        if (!string.IsNullOrWhiteSpace(Name))
+        {
+            return Name!;
+        }
+
+        return $"__crisscross_navhost_{fallbackPrefix}_{RuntimeHelpers.GetHashCode(this):X8}";
     }
 }

--- a/src/CrissCross.Avalonia/ViewModelRoutedViewHost.cs
+++ b/src/CrissCross.Avalonia/ViewModelRoutedViewHost.cs
@@ -111,9 +111,9 @@ public class ViewModelRoutedViewHost : ReactiveTransitioningContentControl, IVie
     /// <value>
     /// The name of the host.
     /// </value>
-    public string? HostName
+    public string HostName
     {
-        get => GetValue(HostNameProperty);
+        get => GetValue(HostNameProperty) ?? string.Empty;
         set => SetValue(HostNameProperty, value);
     }
 

--- a/src/CrissCross.WPF.Plot.Test/App.config
+++ b/src/CrissCross.WPF.Plot.Test/App.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/CrissCross.WPF.Plot.Test/CrissCross.WPF.Plot.Example.csproj
+++ b/src/CrissCross.WPF.Plot.Test/CrissCross.WPF.Plot.Example.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CrissCross.WPF.Plot.Test/ViewModels/MainViewModel.cs
+++ b/src/CrissCross.WPF.Plot.Test/ViewModels/MainViewModel.cs
@@ -17,11 +17,16 @@ namespace CrissCross.WPF.Plot.Test.ViewModels
     /// <seealso cref="RxObject" />
     public partial class MainViewModel : RxObject
     {
-        private readonly Subject<(string? Name, IList<double>? Value, IList<double> DateTime, int Axis)> _signalTicks = new();
+        private const int DemoMaxPoints = 600;
+        private readonly Subject<(string? Name, IList<double>? Value, IList<double> X, int Axis)> _signalPoints = new();
         private readonly Subject<(string? Name, IList<double>? X, IList<double> Y, int Axis)> _scatterPoints = new();
         private readonly Subject<(string? Name, IList<double>? Value, int Axis, int nMaxPoints)> _dataLoggerPoints = new();
         private readonly Subject<(string? Name, IList<double>? Y, IList<double> X, int Axis)> _streamerPoints = new();
         private readonly Subject<(string? Name, IList<double>? Y, IList<double> X, int Axis)> _signalXyPoints = new();
+        private readonly List<double> _scatterXHistory = [];
+        private readonly List<double> _scatterYHistory = [];
+        private readonly List<double> _signalXyXHistory = [];
+        private readonly List<double> _signalXyYHistory = [];
         private readonly SerialDisposable _demoStream = new();
         private bool _demoStreamsStarted;
 
@@ -36,14 +41,14 @@ namespace CrissCross.WPF.Plot.Test.ViewModels
             YAxisNames = (new List<string> { "[Signal]", "[Scatter]", "[Logger]", "[Streamer]", "[SignalXY]" }, new List<string> { "#377eb8", "#ff7f00", "#4daf4a", "#984ea3", "#e41a1c" });
             ReactivePlotSources = Observable.Return<IReadOnlyList<IReactivePlotSource>>(
             [
-                ReactivePlotSource.FromSignalTicks(_signalTicks),
+                ReactivePlotSource.FromSignalPoints(_signalPoints),
                 ReactivePlotSource.FromScatterPoints(_scatterPoints),
                 ReactivePlotSource.FromDataLoggerPoints(_dataLoggerPoints),
                 ReactivePlotSource.FromStreamerPoints(_streamerPoints),
                 ReactivePlotSource.FromSignalXyPoints(_signalXyPoints),
             ]);
 
-            LiveChartSubject = [_signalTicks];
+            LiveChartSubject = [_signalPoints];
             this.WhenAnyValue(vm => vm.LiveChartViewModel)
                 .WhereNotNull()
                 .Subscribe(_ => StartReactiveDemoStreams());
@@ -76,7 +81,7 @@ namespace CrissCross.WPF.Plot.Test.ViewModels
             if (disposing)
             {
                 _demoStream.Dispose();
-                _signalTicks.Dispose();
+                _signalPoints.Dispose();
                 _scatterPoints.Dispose();
                 _dataLoggerPoints.Dispose();
                 _streamerPoints.Dispose();
@@ -89,8 +94,22 @@ namespace CrissCross.WPF.Plot.Test.ViewModels
         private static double NextRandomValue()
         {
             var bytes = new byte[8];
+#if NET472 || NET481
+            using var generator = RandomNumberGenerator.Create();
+            generator.GetBytes(bytes);
+#else
             RandomNumberGenerator.Fill(bytes);
+#endif
             return BitConverter.ToUInt64(bytes, 0) / (double)ulong.MaxValue * 100;
+        }
+
+        private static void AddDemoPoint(List<double> values, double value)
+        {
+            values.Add(value);
+            if (values.Count > DemoMaxPoints)
+            {
+                values.RemoveAt(0);
+            }
         }
 
         private void StartReactiveDemoStreams()
@@ -105,13 +124,23 @@ namespace CrissCross.WPF.Plot.Test.ViewModels
                 .Subscribe(index =>
                 {
                     var x = (double)index;
-                    var y = NextRandomValue();
-                    var ticks = DateTime.Now.Ticks;
-                    _signalTicks.OnNext(("Signal ticks", [y], [ticks], 0));
-                    _scatterPoints.OnNext(("Scatter points", [x], [y], 1));
-                    _dataLoggerPoints.OnNext(("Data logger", [y], 2, 600));
-                    _streamerPoints.OnNext(("Streamer", [y], [x], 3));
-                    _signalXyPoints.OnNext(("SignalXY", [Math.Sin(index / 10.0) * 10.0], [x], 4));
+                    var plotX = x * 10.0;
+                    var signal = 50.0 + (Math.Sin(index / 8.0) * 35.0);
+                    var scatter = 50.0 + (Math.Cos(index / 9.0) * 35.0);
+                    var logger = NextRandomValue();
+                    var streamer = 50.0 + (Math.Sin(index / 5.0) * 45.0);
+                    var signalXy = 50.0 + (Math.Sin(index / 12.0) * 35.0);
+
+                    AddDemoPoint(_scatterXHistory, plotX);
+                    AddDemoPoint(_scatterYHistory, scatter);
+                    AddDemoPoint(_signalXyXHistory, plotX);
+                    AddDemoPoint(_signalXyYHistory, signalXy);
+
+                    _signalPoints.OnNext(("Signal points", [signal], [plotX], 0));
+                    _scatterPoints.OnNext(("Scatter points", _scatterXHistory.ToArray(), _scatterYHistory.ToArray(), 1));
+                    _dataLoggerPoints.OnNext(("Data logger", [logger], 2, DemoMaxPoints));
+                    _streamerPoints.OnNext(("Streamer", [streamer], [plotX], 3));
+                    _signalXyPoints.OnNext(("SignalXY", _signalXyYHistory.ToArray(), _signalXyXHistory.ToArray(), 4));
                 });
         }
     }

--- a/src/CrissCross.WPF.Plot.Test/Views/MainView.xaml.cs
+++ b/src/CrissCross.WPF.Plot.Test/Views/MainView.xaml.cs
@@ -27,11 +27,11 @@ namespace CrissCross.WPF.Plot.Test.Views
             this.WhenActivated(d =>
             {
                 // OneWay bind ViewModel to View
+                this.OneWayBind(ViewModel, vm => vm.YAxisNames, v => v.Chart.YAxisName).DisposeWith(d);
                 ViewModel.ReactivePlotSources
                     .ObserveOn(RxSchedulers.MainThreadScheduler)
                     .Subscribe(sources => Chart.ReactivePlotSources = sources)
                     .DisposeWith(d);
-                this.OneWayBind(ViewModel, vm => vm.YAxisNames, v => v.Chart.YAxisName).DisposeWith(d);
 
                 // OneWay bind View to ViewModel
                 this.WhenAnyValue(x => x.Chart.ViewModel).BindTo(ViewModel, vm => vm.LiveChartViewModel).DisposeWith(d);

--- a/src/CrissCross.WPF.Plot/Controls/ChartObjects.cs
+++ b/src/CrissCross.WPF.Plot/Controls/ChartObjects.cs
@@ -117,7 +117,7 @@ public partial class ChartObjects : RxObject, IAppearance
         // Create a crosshair to highlight the point under the cursor
         Crosshair = wpfPlot.Plot.Add.Crosshair(0, 0);
         Crosshair.IsVisible = false;
-        Crosshair!.LineColor = ScottPlot.Color.FromColor(System.Drawing.Color.FromName(colorName!));
+        Crosshair!.LineColor = ResolveColor(colorName);
 
         // Create a marker to highlight the point under the cursor
         Marker = wpfPlot!.Plot.Add.Marker(0, 0);
@@ -125,7 +125,7 @@ public partial class ChartObjects : RxObject, IAppearance
         Marker.Size = 17;
         Marker.LineWidth = 2;
         Marker.IsVisible = false;
-        Marker!.Color = ScottPlot.Color.FromColor(System.Drawing.Color.FromName(colorName!));
+        Marker!.Color = ResolveColor(colorName);
 
         // Create a text label to place near the highlighted value
         MarkerText = wpfPlot!.Plot.Add.Text(" ", 0, 0);
@@ -134,7 +134,7 @@ public partial class ChartObjects : RxObject, IAppearance
         MarkerText.OffsetX = 7;
         MarkerText.OffsetY = -7;
         MarkerText.IsVisible = false;
-        MarkerText!.LabelFontColor = ScottPlot.Color.FromColor(System.Drawing.Color.FromName(colorName!));
+        MarkerText!.LabelFontColor = ResolveColor(colorName);
         MarkerText.LabelStyle.BackgroundColor = ScottPlot.Colors.White;
     }
 
@@ -156,13 +156,14 @@ public partial class ChartObjects : RxObject, IAppearance
         this.WhenAnyValue(x => x.LineWidth, x => x.Color, x => x.Visibility)
             .Subscribe(x =>
             {
+                var color = ResolveColor(x.Item2);
                 plotable!.LineStyle.Width = (float)x.Item1;
-                plotable!.LineStyle.Color = ScottPlot.Color.FromColor(System.Drawing.Color.FromName(x.Item2!));
+                plotable!.LineStyle.Color = color;
                 IsChecked = x.Item3 != "Invisible";
                 plotable!.IsVisible = x.Item3 != "Invisible";
-                Crosshair!.LineColor = ScottPlot.Color.FromColor(System.Drawing.Color.FromName(x.Item2!));
-                Marker!.Color = ScottPlot.Color.FromColor(System.Drawing.Color.FromName(x.Item2!));
-                MarkerText!.LabelFontColor = ScottPlot.Color.FromColor(System.Drawing.Color.FromName(x.Item2!));
+                Crosshair!.LineColor = color;
+                Marker!.Color = color;
+                MarkerText!.LabelFontColor = color;
                 wpfPlot.Refresh();
             }).DisposeWith(Disposables);
 
@@ -192,10 +193,11 @@ public partial class ChartObjects : RxObject, IAppearance
         this.WhenAnyValue(x => x.LineWidth, x => x.Color, x => x.Visibility)
             .Subscribe(x =>
             {
+                var color = ResolveColor(x.Item2);
                 IsChecked = x.Item3 != "Invisible";
-                Crosshair!.LineColor = ScottPlot.Color.FromColor(System.Drawing.Color.FromName(x.Item2!));
-                Marker!.Color = ScottPlot.Color.FromColor(System.Drawing.Color.FromName(x.Item2!));
-                MarkerText!.LabelFontColor = ScottPlot.Color.FromColor(System.Drawing.Color.FromName(x.Item2!));
+                Crosshair!.LineColor = color;
+                Marker!.Color = color;
+                MarkerText!.LabelFontColor = color;
                 wpfPlot.Refresh();
             }).DisposeWith(Disposables);
 
@@ -229,5 +231,30 @@ public partial class ChartObjects : RxObject, IAppearance
     {
         IsCheckedCmd?.Dispose();
         base.Dispose(disposing);
+    }
+
+    private static ScottPlot.Color ResolveColor(string? colorName)
+    {
+        if (string.IsNullOrWhiteSpace(colorName))
+        {
+            return ScottPlot.Colors.White;
+        }
+
+        if (colorName!.StartsWith("#", StringComparison.Ordinal))
+        {
+            try
+            {
+                return ScottPlot.Color.FromHex(colorName);
+            }
+            catch (FormatException)
+            {
+                return ScottPlot.Colors.White;
+            }
+        }
+
+        var systemColor = System.Drawing.Color.FromName(colorName);
+        return systemColor.A == 0 && !string.Equals(colorName, nameof(System.Drawing.Color.Transparent), StringComparison.OrdinalIgnoreCase)
+            ? ScottPlot.Colors.White
+            : ScottPlot.Color.FromColor(systemColor);
     }
 }

--- a/src/CrissCross.WPF.Plot/Controls/SignalUI.cs
+++ b/src/CrissCross.WPF.Plot/Controls/SignalUI.cs
@@ -103,7 +103,9 @@ public partial class SignalUI : RxObject, IPlottableUI
             ChartSettings.Crosshair!.Position = closestCoordinate;
             ChartSettings.Marker!.Position = closestCoordinate;
             ChartSettings.MarkerText!.Location = closestCoordinate;
-            ChartSettings.MarkerText!.LabelText = $"{closestCoordinate.Y:0.##}\n{DateTime.FromOADate(closestCoordinate.X)}";
+            ChartSettings.MarkerText!.LabelText = _ticks ?
+                $"{closestCoordinate.Y:0.##}\n{DateTime.FromOADate(closestCoordinate.X)}" :
+                $"{closestCoordinate.Y:0.##}\n{closestCoordinate.X:0.##}";
 
             Plot?.Refresh();
         }).DisposeWith(Disposables);

--- a/src/CrissCross.WPF.Plot/Controls/StreamerUI.cs
+++ b/src/CrissCross.WPF.Plot/Controls/StreamerUI.cs
@@ -127,7 +127,7 @@ public partial class StreamerUI : RxObject, IPlottableUI
         var darray = new double[_numberPointsPlottedSaved];
         PlotLine.Data = new(darray);
         PlotLine.ViewScrollLeft();
-        PlotLine.Period = 32000 / 2048;
+        PlotLine.Period = (double)_fs / _nSamples;
         PlotLine.LineStyle.Width = 1f;
         PlotLine.Color = Color.FromHex(color);
     }

--- a/src/CrissCross.WPF.Plot/ReactivePlotSource.cs
+++ b/src/CrissCross.WPF.Plot/ReactivePlotSource.cs
@@ -15,20 +15,29 @@ namespace CrissCross.WPF.Plot;
 public sealed record ReactivePlotSource(PlotSeriesKey Key, PlotType PlotType, IObservable<ReactivePlotUpdate> Updates) : IReactivePlotSource
 {
     /// <summary>
+    /// Gets the X-axis interpretation used by updates emitted from this source when it is known upfront.
+    /// </summary>
+    public PlotXAxisKind? XAxisKind { get; init; }
+
+    /// <summary>
     /// Creates a source from an already-normalized update stream.
     /// </summary>
     /// <param name="key">The stable series key.</param>
     /// <param name="plotType">The chart type.</param>
     /// <param name="updates">The update stream.</param>
+    /// <param name="xAxisKind">The X-axis interpretation used by the source when known upfront.</param>
     /// <returns>A reactive plot source.</returns>
-    public static IReactivePlotSource FromUpdates(PlotSeriesKey key, PlotType plotType, IObservable<ReactivePlotUpdate> updates)
+    public static IReactivePlotSource FromUpdates(PlotSeriesKey key, PlotType plotType, IObservable<ReactivePlotUpdate> updates, PlotXAxisKind? xAxisKind = null)
     {
         if (updates is null)
         {
             throw new ArgumentNullException(nameof(updates));
         }
 
-        return new ReactivePlotSource(key, plotType, updates);
+        return new ReactivePlotSource(key, plotType, updates)
+        {
+            XAxisKind = xAxisKind,
+        };
     }
 
     /// <summary>
@@ -54,7 +63,39 @@ public sealed record ReactivePlotSource(PlotSeriesKey Key, PlotType PlotType, IO
             PlotXAxisKind.Ticks,
             sequence++));
 
-        return new ReactivePlotSource(new PlotSeriesKey(string.Empty, 0), PlotType.Signal, projected);
+        return new ReactivePlotSource(new PlotSeriesKey(string.Empty, 0), PlotType.Signal, projected)
+        {
+            XAxisKind = PlotXAxisKind.Ticks,
+        };
+    }
+
+    /// <summary>
+    /// Adapts legacy signal point observables to append updates with numeric X-axis values.
+    /// </summary>
+    /// <param name="updates">The legacy signal point stream.</param>
+    /// <returns>A reactive signal source.</returns>
+    public static IReactivePlotSource FromSignalPoints(IObservable<(string? Name, IList<double>? Value, IList<double> X, int Axis)> updates)
+    {
+        if (updates is null)
+        {
+            throw new ArgumentNullException(nameof(updates));
+        }
+
+        var sequence = 0L;
+        var projected = updates.Select(update => CreateUpdate(
+            update.Name,
+            update.Axis,
+            PlotType.Signal,
+            ReactivePlotUpdateKind.Append,
+            update.X,
+            update.Value,
+            PlotXAxisKind.Numeric,
+            sequence++));
+
+        return new ReactivePlotSource(new PlotSeriesKey(string.Empty, 0), PlotType.Signal, projected)
+        {
+            XAxisKind = PlotXAxisKind.Numeric,
+        };
     }
 
     /// <summary>
@@ -80,7 +121,10 @@ public sealed record ReactivePlotSource(PlotSeriesKey Key, PlotType PlotType, IO
             PlotXAxisKind.Numeric,
             sequence++));
 
-        return new ReactivePlotSource(new PlotSeriesKey(string.Empty, 0), PlotType.Scatter, projected);
+        return new ReactivePlotSource(new PlotSeriesKey(string.Empty, 0), PlotType.Scatter, projected)
+        {
+            XAxisKind = PlotXAxisKind.Numeric,
+        };
     }
 
     /// <summary>
@@ -103,7 +147,10 @@ public sealed record ReactivePlotSource(PlotSeriesKey Key, PlotType PlotType, IO
             return CreateUpdate(update.Name, update.Axis, PlotType.DataLogger, ReactivePlotUpdateKind.Append, x, update.Value, PlotXAxisKind.Numeric, sequence++, maxPoints);
         });
 
-        return new ReactivePlotSource(new PlotSeriesKey(string.Empty, 0), PlotType.DataLogger, projected);
+        return new ReactivePlotSource(new PlotSeriesKey(string.Empty, 0), PlotType.DataLogger, projected)
+        {
+            XAxisKind = PlotXAxisKind.Numeric,
+        };
     }
 
     /// <summary>
@@ -129,7 +176,10 @@ public sealed record ReactivePlotSource(PlotSeriesKey Key, PlotType PlotType, IO
             PlotXAxisKind.Numeric,
             sequence++));
 
-        return new ReactivePlotSource(new PlotSeriesKey(string.Empty, 0), PlotType.Streamer, projected);
+        return new ReactivePlotSource(new PlotSeriesKey(string.Empty, 0), PlotType.Streamer, projected)
+        {
+            XAxisKind = PlotXAxisKind.Numeric,
+        };
     }
 
     /// <summary>
@@ -155,7 +205,10 @@ public sealed record ReactivePlotSource(PlotSeriesKey Key, PlotType PlotType, IO
             PlotXAxisKind.Numeric,
             sequence++));
 
-        return new ReactivePlotSource(new PlotSeriesKey(string.Empty, 0), PlotType.SignalXY, projected);
+        return new ReactivePlotSource(new PlotSeriesKey(string.Empty, 0), PlotType.SignalXY, projected)
+        {
+            XAxisKind = PlotXAxisKind.Numeric,
+        };
     }
 
     /// <summary>

--- a/src/CrissCross.WPF.Plot/Views/LiveChart.xaml.cs
+++ b/src/CrissCross.WPF.Plot/Views/LiveChart.xaml.cs
@@ -154,14 +154,16 @@ public partial class LiveChart : ReactiveUI.ReactiveUserControl<LiveChartViewMod
         _needCrossHairOff = true;
         ExecuteMarkerOnOff();
         ViewModel.ClearContent();
+        var sourceArray = sources as IReactivePlotSource[] ?? sources.ToArray();
+        ConfigureReactivePlotXAxis(sourceArray);
         _reactivePlotConnection = new ReactivePlotBinder().Bind(
             ViewModel,
-            sources,
+            sourceArray,
             new ReactivePlotBindingOptions
             {
                 UiScheduler = RxSchedulers.MainThreadScheduler,
                 MaxVisiblePoints = UseFixedNumberOfPoints ? NumberPointsPlotted : null,
-                MaxAxisCount = ViewModel.YAxisList.Count,
+                MaxAxisCount = Math.Max(1, ViewModel.YAxisList.Count),
             });
         ViewModel.InitializeAxisLines();
     }
@@ -547,7 +549,35 @@ public partial class LiveChart : ReactiveUI.ReactiveUserControl<LiveChartViewMod
         }
     }
 
-    private void YAxisSetup() => ViewModel!.YAxesSetup(YAxisName);
+    private void YAxisSetup()
+    {
+        var (yNames, hexColors) = YAxisName;
+        if (ViewModel is null || yNames is null || hexColors is null || yNames.Count == 0 || hexColors.Count == 0)
+        {
+            return;
+        }
+
+        ViewModel.YAxesSetup(YAxisName);
+    }
+
+    private void ConfigureReactivePlotXAxis(IEnumerable<IReactivePlotSource> sources)
+    {
+        var xAxisKinds = sources
+            .OfType<ReactivePlotSource>()
+            .Select(source => source.XAxisKind)
+            .Where(kind => kind is not null)
+            .Select(kind => kind!.Value)
+            .Distinct()
+            .ToArray();
+
+        if (xAxisKinds.Length == 1 && xAxisKinds[0] is PlotXAxisKind.OADate or PlotXAxisKind.Ticks)
+        {
+            ViewModel!.CreateAxisWithTimeStamp();
+            return;
+        }
+
+        ViewModel!.CreateAxisWithPoints();
+    }
 
     private void MainChartGrid_MouseDown(object sender, MouseEventArgs e)
     {

--- a/src/CrissCross.WPF.Plot/Views/LiveChart{Dependencies}.cs
+++ b/src/CrissCross.WPF.Plot/Views/LiveChart{Dependencies}.cs
@@ -217,7 +217,11 @@ public partial class LiveChart
     /// names with a LiveChart instance. It enables data binding and styling for Y axis labels in XAML-based
     /// applications.</remarks>
     public static readonly DependencyProperty YAxisNameProperty =
-        DependencyProperty.Register(nameof(YAxisName), typeof((IList<string>, IList<string>)), typeof(LiveChart));
+        DependencyProperty.Register(
+            nameof(YAxisName),
+            typeof((IList<string>, IList<string>)),
+            typeof(LiveChart),
+            new PropertyMetadata(default((IList<string> yNames, IList<string> hexColors)), new PropertyChangedCallback(YAxisNameCallback)));
 
     /// <summary>
     /// Identifies the ControlMenu dependency property, which represents a collection of chart objects associated with
@@ -260,6 +264,25 @@ public partial class LiveChart
         if (d is LiveChart livechart)
         {
             livechart.ChangeReactivePlotSources(e.NewValue as IEnumerable<IReactivePlotSource>);
+        }
+    }
+
+    /// <summary>
+    /// Handles axis metadata changes by rebuilding chart axes before reactive plot sources are rebound.
+    /// </summary>
+    /// <param name="d">The dependency object on which the property changed.</param>
+    /// <param name="e">The dependency property change event arguments.</param>
+    private static void YAxisNameCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not LiveChart livechart)
+        {
+            return;
+        }
+
+        livechart.YAxisSetup();
+        if (livechart.ReactivePlotSources is not null)
+        {
+            livechart.ChangeReactivePlotSources(livechart.ReactivePlotSources);
         }
     }
 

--- a/src/CrissCross.WPF.Plot/Views/LiveChart{Properties}.cs
+++ b/src/CrissCross.WPF.Plot/Views/LiveChart{Properties}.cs
@@ -241,11 +241,7 @@ public partial class LiveChart
     public (IList<string> yNames, IList<string> hexColors) YAxisName
     {
         get => ((IList<string> yNames, IList<string> hexColors))GetValue(YAxisNameProperty);
-        set
-        {
-            SetValue(YAxisNameProperty, value);
-            YAxisSetup();
-        }
+        set => SetValue(YAxisNameProperty, value);
     }
 
 #if NET8_0_OR_GREATER

--- a/src/CrissCross.WPF.Plot/WpfReactivePlotAdapter.cs
+++ b/src/CrissCross.WPF.Plot/WpfReactivePlotAdapter.cs
@@ -21,6 +21,7 @@ internal sealed class WpfReactivePlotAdapter : IReactivePlotAdapter
     private readonly List<double> _retainedX = [];
     private readonly List<double> _retainedY = [];
     private IPlottableUI? _ui;
+    private PlotXAxisKind? _signalXAxisKind;
     private bool _disposed;
 
     public WpfReactivePlotAdapter(LiveChartViewModel chart, PlotSeriesKey key, PlotType plotType, string color)
@@ -34,8 +35,6 @@ internal sealed class WpfReactivePlotAdapter : IReactivePlotAdapter
         {
             case PlotType.Signal:
                 _signalSubject = new Subject<(string? Name, IList<double>? Value, IList<double> X, int Axis)>();
-                _ui = new SignalUI(_chart.WpfPlot1vm!, _signalSubject, _chart.MouseCoordinatesObservable, _color, fixedPoints: _chart.WhenAnyValue(x => x.UseFixedNumberOfPoints), numberPointsPlotted: _chart.WhenAnyValue(x => x.NumberPointsPlotted));
-                AddUi();
                 break;
             case PlotType.Scatter:
                 _scatterSubject = new Subject<(string? Name, IList<double>? X, IList<double> Y, int Axis)>();
@@ -84,6 +83,7 @@ internal sealed class WpfReactivePlotAdapter : IReactivePlotAdapter
         switch (PlotType)
         {
             case PlotType.Signal:
+                EnsureSignalUi(update.XAxisKind);
                 _signalSubject?.OnNext((update.Key.Name, update.Y.ToList(), update.X.ToList(), update.Key.Axis));
                 break;
             case PlotType.Scatter:
@@ -134,6 +134,33 @@ internal sealed class WpfReactivePlotAdapter : IReactivePlotAdapter
         _chart.PlotLinesCollectionUI.Add(_ui);
         _chart.UpdateChartObjectsCollection();
         AssignAxis(Key.Axis);
+    }
+
+    private void EnsureSignalUi(PlotXAxisKind xAxisKind)
+    {
+        if (_ui is SignalUI && _signalXAxisKind == xAxisKind)
+        {
+            return;
+        }
+
+        if (_ui is not null)
+        {
+            _chart.PlotLinesCollectionUI.Remove(_ui);
+            _ui.Dispose();
+            _ui = null;
+            _chart.UpdateChartObjectsCollection();
+        }
+
+        _signalXAxisKind = xAxisKind;
+        _ui = new SignalUI(
+            _chart.WpfPlot1vm!,
+            _signalSubject!,
+            _chart.MouseCoordinatesObservable,
+            _color,
+            fixedPoints: _chart.WhenAnyValue(x => x.UseFixedNumberOfPoints),
+            numberPointsPlotted: _chart.WhenAnyValue(x => x.NumberPointsPlotted),
+            ticks: xAxisKind == PlotXAxisKind.Ticks);
+        AddUi();
     }
 
     private ReactivePlotUpdate PrepareSnapshotUpdate(ReactivePlotUpdate update)

--- a/src/CrissCross.WPF.UI/Controls/GifImage/Decoding/GifHelpers.cs
+++ b/src/CrissCross.WPF.UI/Controls/GifImage/Decoding/GifHelpers.cs
@@ -33,7 +33,7 @@ internal static class GifHelpers
         while ((len = await sourceStream.ReadByteAsync(cancellationToken)) > 0)
         {
             await sourceStream.ReadAllAsync(buffer, 0, len, cancellationToken).ConfigureAwait(false);
-            await targetStream.WriteAsync(buffer.AsMemory(0, len), cancellationToken);
+            await targetStream.WriteBufferAsync(buffer, 0, len, cancellationToken);
         }
     }
 

--- a/src/CrissCross.WPF.UI/Controls/GifImage/Extensions/StreamExtensions.cs
+++ b/src/CrissCross.WPF.UI/Controls/GifImage/Extensions/StreamExtensions.cs
@@ -11,7 +11,7 @@ internal static class StreamExtensions
         var totalRead = 0;
         while (totalRead < count)
         {
-            var n = await stream.ReadAsync(buffer.AsMemory(offset + totalRead, count - totalRead), cancellationToken);
+            var n = await stream.ReadBufferAsync(buffer, offset + totalRead, count - totalRead, cancellationToken);
             if (n == 0)
             {
                 throw new EndOfStreamException();
@@ -39,7 +39,7 @@ internal static class StreamExtensions
     public static async Task<int> ReadByteAsync(this Stream stream, CancellationToken cancellationToken = default)
     {
         var buffer = new byte[1];
-        var n = await stream.ReadAsync(buffer.AsMemory(0, 1), cancellationToken);
+        var n = await stream.ReadBufferAsync(buffer, 0, 1, cancellationToken);
         return n switch
         {
             0 => -1,
@@ -62,11 +62,29 @@ internal static class StreamExtensions
         var buffer = new byte[bufferSize];
         int bytesRead;
         long bytesCopied = 0;
-        while ((bytesRead = await source.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false)) != 0)
+        while ((bytesRead = await source.ReadBufferAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false)) != 0)
         {
-            await destination.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
+            await destination.WriteBufferAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
             bytesCopied += bytesRead;
             progress?.Report(bytesCopied);
         }
+    }
+
+    public static Task<int> ReadBufferAsync(this Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
+    {
+#if NET472 || NET481
+        return stream.ReadAsync(buffer, offset, count, cancellationToken);
+#else
+        return stream.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+#endif
+    }
+
+    public static Task WriteBufferAsync(this Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
+    {
+#if NET472 || NET481
+        return stream.WriteAsync(buffer, offset, count, cancellationToken);
+#else
+        return stream.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+#endif
     }
 }

--- a/src/CrissCross/MagicInterfaces/IAmBuilt.cs
+++ b/src/CrissCross/MagicInterfaces/IAmBuilt.cs
@@ -5,6 +5,6 @@
 namespace CrissCross;
 
 /// <summary>
-/// IAmBuilt.
+/// Marker interface indicating that a type has been built or constructed.
 /// </summary>
 public interface IAmBuilt;

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -39,9 +39,9 @@
     <PackageVersion Include="Microsoft.Web.WebView2" Version="$(WebViewVersion)" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.142" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="$(DotNetVersion)" />
-    <PackageVersion Include="Polyfill" Version="10.5.1" Condition="!$(TargetFramework.StartsWith('net4'))" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
 
     <!-- Source Generators (PrivateAssets) -->
     <PackageVersion Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" />
@@ -60,7 +60,7 @@
     <PackageVersion Include="ScottPlot.WPF" Version="5.1.58" />
 
     <!-- Polyfill for .NET Framework -->
-    <PackageVersion Include="Polyfill" Version="9.24.1" Condition="$(TargetFramework.StartsWith('net4'))" />
+    <PackageVersion Include="Polyfill" Version="10.5.1" Condition="$(TargetFramework.StartsWith('net4'))" />
 
     <!-- Testing Packages -->
     <PackageVersion Include="TUnit" Version="1.44.39" Condition="$(IsTestProject)" />

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaNavigationUserControlRegressionTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaNavigationUserControlRegressionTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using AvaloniaNavigationUserControl = CrissCross.Avalonia.NavigationUserControl;
+
+namespace CrissCross.NavigationView.Tests;
+
+/// <summary>
+/// Regression tests for Avalonia navigation host setup.
+/// </summary>
+public class AvaloniaNavigationUserControlRegressionTests
+{
+    [Test]
+    public async Task OnInitialized_WhenControlHasName_UsesExistingNameForNavigationHost()
+    {
+        var control = new TestNavigationUserControl
+        {
+            Name = "mainWindow"
+        };
+
+        control.InitializeForTest();
+
+        await Assert.That(control.Name).IsEqualTo("mainWindow");
+        await Assert.That(((IUseNavigation)control).Name).IsEqualTo("mainWindow");
+        await Assert.That(control.NavigationFrame?.HostName).IsEqualTo("mainWindow");
+        await Assert.That(control.NavigationFrame?.Name).IsEqualTo("mainWindow");
+    }
+
+    [Test]
+    public async Task OnInitialized_WhenControlHasNoName_UsesGeneratedHostNameWithoutSettingElementName()
+    {
+        var control = new TestNavigationUserControl();
+
+        control.InitializeForTest();
+
+        var hostName = ((IUseNavigation)control).Name;
+
+        await Assert.That(control.Name).IsNull();
+        await Assert.That(string.IsNullOrWhiteSpace(hostName)).IsFalse();
+        await Assert.That(hostName!.StartsWith("__crisscross_navhost_NavigationUserControl_", StringComparison.Ordinal)).IsTrue();
+        await Assert.That(control.NavigationFrame?.HostName).IsEqualTo(hostName);
+        await Assert.That(control.NavigationFrame?.Name).IsEqualTo(hostName);
+    }
+
+    private sealed class TestNavigationUserControl : AvaloniaNavigationUserControl
+    {
+        public void InitializeForTest() => OnInitialized();
+    }
+}

--- a/src/Tests/CrissCross.NavigationView.Tests/CrissCross.NavigationView.Tests.csproj
+++ b/src/Tests/CrissCross.NavigationView.Tests/CrissCross.NavigationView.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\CrissCross.WPF.UI\CrissCross.WPF.UI.csproj" />
+    <ProjectReference Include="..\..\CrissCross.Avalonia\CrissCross.Avalonia.csproj" />
     <ProjectReference Include="..\..\CrissCross.Avalonia.UI\CrissCross.Avalonia.UI.csproj" />
     <Using Include="TUnit.Core" />
     <Using Include="TUnit.Assertions" />

--- a/src/Tests/CrissCross.WPF.Plot.Tests/ReactivePlotBinderTests.cs
+++ b/src/Tests/CrissCross.WPF.Plot.Tests/ReactivePlotBinderTests.cs
@@ -34,6 +34,25 @@ public sealed class ReactivePlotBinderTests
     }
 
     [Test]
+    public async Task SignalPointsAdapter_EmitsAppendUpdateWithNumericXAxisKind()
+    {
+        IObservable<(string? Name, IList<double>? Value, IList<double> X, int Axis)> points =
+            Observable.Return((Name: (string?)"Motor", Value: (IList<double>?)[1.0, 2.0], X: (IList<double>)[10.0, 20.0], Axis: 2));
+        var source = ReactivePlotSource.FromSignalPoints(points);
+
+        var update = await source.Updates.FirstAsync();
+
+        await Assert.That(source.PlotType).IsEqualTo(PlotType.Signal);
+        await Assert.That(update.PlotType).IsEqualTo(PlotType.Signal);
+        await Assert.That(update.Kind).IsEqualTo(ReactivePlotUpdateKind.Append);
+        await Assert.That(update.XAxisKind).IsEqualTo(PlotXAxisKind.Numeric);
+        await Assert.That(((ReactivePlotSource)source).XAxisKind).IsEqualTo(PlotXAxisKind.Numeric);
+        await Assert.That(update.Key).IsEqualTo(new PlotSeriesKey("Motor", 2));
+        await Assert.That(update.X).IsEquivalentTo([10.0, 20.0]);
+        await Assert.That(update.Y).IsEquivalentTo([1.0, 2.0]);
+    }
+
+    [Test]
     public async Task SignalXyAdapter_SupportsObservableReplaceUpdates()
     {
         var snapshots = new Subject<(string? Name, IList<double>? Y, IList<double> X, int Axis)>();

--- a/src/Tests/CrissCross.WPF.Plot.Tests/ReactivePlotExampleCoverageTests.cs
+++ b/src/Tests/CrissCross.WPF.Plot.Tests/ReactivePlotExampleCoverageTests.cs
@@ -22,7 +22,7 @@ public sealed class ReactivePlotExampleCoverageTests
         var dependencies = ReadSource("CrissCross.WPF.Plot", "Views", "LiveChart{Dependencies}.cs");
         var documentation = ReadRepositoryFile("docs", "reactive-wpf-plot-streams.md");
 
-        await Assert.That(viewModel).Contains("ReactivePlotSource.FromSignalTicks");
+        await Assert.That(viewModel).Contains("ReactivePlotSource.FromSignalPoints");
         await Assert.That(viewModel).Contains("ReactivePlotSource.FromScatterPoints");
         await Assert.That(viewModel).Contains("ReactivePlotSource.FromDataLoggerPoints");
         await Assert.That(viewModel).Contains("ReactivePlotSource.FromStreamerPoints");
@@ -32,7 +32,7 @@ public sealed class ReactivePlotExampleCoverageTests
         await Assert.That(view).Contains("ReactivePlotSources");
         await Assert.That(properties).Contains("IEnumerable<IReactivePlotSource>?");
         await Assert.That(dependencies).Contains("ReactivePlotSourcesProperty");
-        await Assert.That(documentation).Contains("ReactivePlotSource.FromSignalTicks");
+        await Assert.That(documentation).Contains("ReactivePlotSource.FromSignalPoints");
         await Assert.That(documentation).Contains("ReactivePlotSource.FromSignalXyPoints");
         await Assert.That(documentation).Contains("ReactivePlotBindingOptions");
     }


### PR DESCRIPTION
Add explicit numeric X-axis support and adapt UI/adapter/tests accordingly. 
Introduces ReactivePlotSource.XAxisKind and a new FromSignalPoints adapter to handle legacy signal point streams with numeric X values; LiveChart now inspects source XAxisKind to choose a numeric or timestamp axis and WpfReactivePlotAdapter ensures SignalUI is created with the correct ticks behavior. 
Also: improve color resolution (ChartObjects.ResolveColor), fix Streamer period calculation, add buffered read/write helpers for Stream compatibility across frameworks, and update docs/example (reactive-wpf-plot-streams.md) and tests (including new Avalonia navigation regression tests). 
Dependency updates and an App.config binding for System.Runtime.CompilerServices.Unsafe were added to ensure runtime compatibility.

Fixes #245 