### PR TITLE
Improve theming and dynamic resource support

### DIFF
--- a/src/CrissCross.Avalonia.UI.Gallery/ViewModels/FeaturePlaygroundPageViewModel.cs
+++ b/src/CrissCross.Avalonia.UI.Gallery/ViewModels/FeaturePlaygroundPageViewModel.cs
@@ -10,6 +10,8 @@ using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using CrissCross.Avalonia.UI;
+using CrissCross.Avalonia.UI.Appearance;
 using ReactiveUI;
 
 namespace CrissCross.Avalonia.UI.Gallery.ViewModels;
@@ -44,7 +46,7 @@ public sealed class FeaturePlaygroundPageViewModel : RxObject, IUseHostedNavigat
         _currentRange = CreateRange(DateTimeOffset.Now);
         _segmentState = new SegmentedSelectionState(CreateSegments(), "table");
         _stepperState = new StepperState(CreateSteps("review"), "review", StepperOrientation.Horizontal);
-        _themeState = new ThemePreferenceState(_selectedTheme, ThemeChoice.Dark, supportsHighContrast: true);
+        _themeState = CreateThemeState(_selectedTheme);
 
         RunImportCommand = ReactiveCommand.CreateFromTask(RunImportAsync);
         SearchCommand = ReactiveCommand.CreateFromTask<string>(SearchAsync);
@@ -208,7 +210,7 @@ public sealed class FeaturePlaygroundPageViewModel : RxObject, IUseHostedNavigat
             }
 
             this.RaiseAndSetIfChanged(ref _selectedTheme, value);
-            ThemeState = new ThemePreferenceState(value, ThemeChoice.Dark, supportsHighContrast: true);
+            ThemeState = CreateThemeState(value);
         }
     }
 
@@ -287,6 +289,16 @@ public sealed class FeaturePlaygroundPageViewModel : RxObject, IUseHostedNavigat
         new StepDescriptor("review", "Review", currentKey == "review" ? StepStatus.Active : StepStatus.Pending),
         new StepDescriptor("publish", "Publish", StepStatus.Pending, canEnter: currentKey == "review")
     ];
+
+    private static ThemePreferenceState CreateThemeState(ThemeChoice selectedChoice) =>
+        new(selectedChoice, GetSystemThemeChoice(), supportsHighContrast: true);
+
+    private static ThemeChoice GetSystemThemeChoice() => new ThemeService().GetSystemTheme() switch
+    {
+        ApplicationTheme.Dark => ThemeChoice.Dark,
+        ApplicationTheme.HighContrast => ThemeChoice.HighContrast,
+        _ => ThemeChoice.Light
+    };
 
     private async Task RunImportAsync(CancellationToken cancellationToken)
     {

--- a/src/CrissCross.Avalonia.UI.Gallery/Views/MainWindow.axaml
+++ b/src/CrissCross.Avalonia.UI.Gallery/Views/MainWindow.axaml
@@ -3,9 +3,34 @@
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:nav="https://github.com/reactivemarbles/CrissCross"
+    xmlns:ui="using:CrissCross.Avalonia.UI.Controls"
     xmlns:vm="using:CrissCross.Avalonia.UI.Gallery.ViewModels"
     Name="mainNavHost"
     Title="CrissCross Avalonia UI Gallery"
     Width="1200"
     Height="800"
-    x:DataType="vm:MainViewModel" />
+    x:DataType="vm:MainViewModel">
+    <nav:NavigationWindow.Styles>
+        <Style Selector="nav|NavigationWindow">
+            <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            <Setter Property="Foreground" Value="{DynamicResource WindowForeground}" />
+        </Style>
+
+        <Style Selector="ui|Border.gallery-title">
+            <Setter Property="Background" Value="{DynamicResource SolidBackgroundFillColorSecondaryBrush}" />
+        </Style>
+
+        <Style Selector="ui|Border.gallery-navigation">
+            <Setter Property="Background" Value="{DynamicResource SolidBackgroundFillColorBaseBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefaultBrush}" />
+        </Style>
+
+        <Style Selector="ui|Border.gallery-content">
+            <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+        </Style>
+
+        <Style Selector="ui|TextBlock.gallery-shell-text">
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+        </Style>
+    </nav:NavigationWindow.Styles>
+</nav:NavigationWindow>

--- a/src/CrissCross.Avalonia.UI.Gallery/Views/MainWindow.axaml.cs
+++ b/src/CrissCross.Avalonia.UI.Gallery/Views/MainWindow.axaml.cs
@@ -87,16 +87,16 @@ public partial class MainWindow : NavigationWindow<MainViewModel>
             // Title Bar using CrissCross Border
             var titleBorder = new UI.Controls.Border
             {
-                Background = Brush.Parse("#2D2D30"),
                 Padding = new Thickness(16, 12)
             };
+            titleBorder.Classes.Add("gallery-title");
             var titleText = new UI.Controls.TextBlock
             {
                 Text = "CrissCross Avalonia UI Gallery",
                 FontSize = 24,
-                FontWeight = FontWeight.Bold,
-                Foreground = Brushes.White
+                FontWeight = FontWeight.Bold
             };
+            titleText.Classes.Add("gallery-shell-text");
             titleBorder.Child = titleText;
             mainGrid.Children.Add(titleBorder);
             Grid.SetRow(titleBorder, 0);
@@ -111,10 +111,9 @@ public partial class MainWindow : NavigationWindow<MainViewModel>
             // Navigation Menu using CrissCross Border
             var navBorder = new UI.Controls.Border
             {
-                Background = Brush.Parse("#252526"),
-                BorderBrush = Brush.Parse("#3F3F46"),
                 BorderThickness = new Thickness(0, 0, 1, 0)
             };
+            navBorder.Classes.Add("gallery-navigation");
             var navScrollViewer = new ScrollViewer();
             var navStack = new UI.Controls.StackPanel { Margin = new Thickness(8) };
 
@@ -124,9 +123,9 @@ public partial class MainWindow : NavigationWindow<MainViewModel>
                 Text = "Control Categories",
                 FontSize = 16,
                 FontWeight = FontWeight.Bold,
-                Foreground = Brushes.White,
                 Margin = new Thickness(8, 8, 8, 16)
             };
+            navHeader.Classes.Add("gallery-shell-text");
             navStack.Children.Add(navHeader);
 
             // Home button using CrissCross Button
@@ -205,10 +204,10 @@ public partial class MainWindow : NavigationWindow<MainViewModel>
             // Content Display Area with NavigationFrame from base class using CrissCross Border
             var contentBorder = new UI.Controls.Border
             {
-                Background = Brush.Parse("#1E1E1E"),
                 Padding = new Thickness(0),
                 Child = NavigationFrame
             };
+            contentBorder.Classes.Add("gallery-content");
             contentGrid.Children.Add(contentBorder);
             Grid.SetColumn(contentBorder, 1);
 

--- a/src/CrissCross.Avalonia.UI/Controls/ThemeSwitcher/ThemeSwitcher.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/ThemeSwitcher/ThemeSwitcher.cs
@@ -134,13 +134,15 @@ public class ThemeSwitcher : TemplatedControl
     /// <param name="choice">The requested theme choice or name.</param>
     public void ApplyChoice(object? choice)
     {
+        var themeService = ThemeService ?? new ThemeService();
         var selectedChoice = ParseChoice(choice);
+        SystemChoice = ToThemeChoice(themeService.GetSystemTheme());
         SelectedChoice = selectedChoice;
 
         var state = CreateState();
         CurrentState = state;
 
-        ApplyTheme(ThemeService, state.EffectiveChoice);
+        ApplyTheme(themeService, state.EffectiveChoice);
 
         if (ThemeChangedCommand?.CanExecute(selectedChoice) == true)
         {
@@ -188,6 +190,13 @@ public class ThemeSwitcher : TemplatedControl
         ThemeChoice.Dark => ApplicationTheme.Dark,
         ThemeChoice.HighContrast => ApplicationTheme.HighContrast,
         _ => ApplicationTheme.Light
+    };
+
+    private static ThemeChoice ToThemeChoice(ApplicationTheme theme) => theme switch
+    {
+        ApplicationTheme.Dark => ThemeChoice.Dark,
+        ApplicationTheme.HighContrast => ThemeChoice.HighContrast,
+        _ => ThemeChoice.Light
     };
 
     private sealed class ThemeSwitcherCommand : ICommand

--- a/src/CrissCross.Avalonia.UI/Resources/Theme/Dark.axaml
+++ b/src/CrissCross.Avalonia.UI/Resources/Theme/Dark.axaml
@@ -303,8 +303,30 @@
     <SolidColorBrush x:Key="TextControlBackgroundDisabled" Color="{StaticResource ControlFillColorDisabled}" />
     <SolidColorBrush x:Key="TextControlForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="TextControlForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="TextControlBorderBrush" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="TextControlBorderBrushPointerOver" Color="{StaticResource ControlStrokeColorSecondary}" />
+    <SolidColorBrush x:Key="TextControlBorderBrushFocused" Color="{StaticResource SystemAccentColorPrimary}" />
     <SolidColorBrush x:Key="TextControlFocusedBorderBrush" Color="{StaticResource SystemAccentColorPrimary}" />
     <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="{StaticResource TextFillColorSecondary}" />
+
+    <!-- ComboBox -->
+    <SolidColorBrush x:Key="ComboBoxBackground" Color="{StaticResource ControlFillColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundFocused" Color="{StaticResource ControlFillColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource ControlFillColorDisabled}" />
+    <SolidColorBrush x:Key="ComboBoxForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrush" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushPointerOver" Color="{StaticResource ControlStrokeColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemAccentColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxPlaceholderForeground" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SurfaceStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxItemBackgroundSelected" Color="{StaticResource SubtleFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxItemForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ComboBoxItemForegroundSelected" Color="{StaticResource TextFillColorPrimary}" />
 
     <!-- ContentDialog -->
     <SolidColorBrush x:Key="ContentDialogSmokeFill" Color="{StaticResource SmokeFillColorDefault}" />
@@ -319,11 +341,18 @@
     <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOver" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="NavigationViewItemForegroundPressed" Color="{StaticResource TextFillColorSecondary}" />
     <SolidColorBrush x:Key="NavigationViewSelectionIndicatorForeground" Color="{StaticResource SystemAccentColorPrimary}" />
+    <SolidColorBrush x:Key="NavigationViewDefaultPaneBackground" Color="{StaticResource LayerFillColorDefault}" />
+    <SolidColorBrush x:Key="NavigationViewItemSeparatorForeground" Color="{StaticResource DividerStrokeColorDefault}" />
     <SolidColorBrush x:Key="NavigationViewItemBackground" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="NavigationViewItemBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
     <SolidColorBrush x:Key="NavigationViewItemBackgroundSelected" Color="{StaticResource SubtleFillColorSecondary}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundPressed" Color="{StaticResource SubtleFillColorTertiary}" />
+    <SolidColorBrush x:Key="NavigationViewItemBorderBrush" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="NavigationViewContentBackground" Color="{StaticResource LayerFillColorDefault}" />
     <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundSelectedLeftFluent" Color="{StaticResource ControlFillColorDefault}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOverLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
 
     <!-- Card -->
     <SolidColorBrush x:Key="CardBackground" Color="{StaticResource CardBackgroundFillColorDefault}" />

--- a/src/CrissCross.Avalonia.UI/Resources/Theme/Light.axaml
+++ b/src/CrissCross.Avalonia.UI/Resources/Theme/Light.axaml
@@ -303,8 +303,30 @@
     <SolidColorBrush x:Key="TextControlBackgroundDisabled" Color="{StaticResource ControlFillColorDisabled}" />
     <SolidColorBrush x:Key="TextControlForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="TextControlForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="TextControlBorderBrush" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="TextControlBorderBrushPointerOver" Color="{StaticResource ControlStrokeColorSecondary}" />
+    <SolidColorBrush x:Key="TextControlBorderBrushFocused" Color="{StaticResource SystemAccentColorPrimary}" />
     <SolidColorBrush x:Key="TextControlFocusedBorderBrush" Color="{StaticResource SystemAccentColorPrimary}" />
     <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="{StaticResource TextFillColorSecondary}" />
+
+    <!-- ComboBox -->
+    <SolidColorBrush x:Key="ComboBoxBackground" Color="{StaticResource ControlFillColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundFocused" Color="{StaticResource ControlFillColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource ControlFillColorDisabled}" />
+    <SolidColorBrush x:Key="ComboBoxForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrush" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushPointerOver" Color="{StaticResource ControlStrokeColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemAccentColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxPlaceholderForeground" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SurfaceStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxItemBackgroundSelected" Color="{StaticResource SubtleFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxItemForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ComboBoxItemForegroundSelected" Color="{StaticResource TextFillColorPrimary}" />
 
     <!-- ContentDialog -->
     <SolidColorBrush x:Key="ContentDialogSmokeFill" Color="{StaticResource SmokeFillColorDefault}" />
@@ -319,11 +341,18 @@
     <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOver" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="NavigationViewItemForegroundPressed" Color="{StaticResource TextFillColorSecondary}" />
     <SolidColorBrush x:Key="NavigationViewSelectionIndicatorForeground" Color="{StaticResource SystemAccentColorPrimary}" />
+    <SolidColorBrush x:Key="NavigationViewDefaultPaneBackground" Color="{StaticResource LayerFillColorDefault}" />
+    <SolidColorBrush x:Key="NavigationViewItemSeparatorForeground" Color="{StaticResource DividerStrokeColorDefault}" />
     <SolidColorBrush x:Key="NavigationViewItemBackground" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="NavigationViewItemBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
     <SolidColorBrush x:Key="NavigationViewItemBackgroundSelected" Color="{StaticResource SubtleFillColorSecondary}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundPressed" Color="{StaticResource SubtleFillColorTertiary}" />
+    <SolidColorBrush x:Key="NavigationViewItemBorderBrush" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="NavigationViewContentBackground" Color="{StaticResource LayerFillColorDefault}" />
     <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundSelectedLeftFluent" Color="{StaticResource ControlFillColorDefault}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOverLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
 
     <!-- Card -->
     <SolidColorBrush x:Key="CardBackground" Color="{StaticResource CardBackgroundFillColorDefault}" />

--- a/src/CrissCross.Avalonia.UI/Themes/ComboBox.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ComboBox.axaml
@@ -5,9 +5,9 @@
     <!-- CrissCross ComboBox Style -->
     <!-- Inherits from Avalonia ComboBox - use native styling with minimal overrides -->
     <Style Selector="controls|ComboBox">
-        <Setter Property="Background" Value="#3D3D3D" />
-        <Setter Property="Foreground" Value="#FFFFFF" />
-        <Setter Property="BorderBrush" Value="#5D5D5D" />
+        <Setter Property="Background" Value="{DynamicResource ComboBoxBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="MinWidth" Value="150" />
         <Setter Property="MinHeight" Value="32" />
@@ -39,7 +39,7 @@
                         <TextBlock Name="PlaceholderText"
                                    Grid.Column="0"
                                    Text="{TemplateBinding PlaceholderText}"
-                                   Foreground="#808080"
+                                   Foreground="{DynamicResource ComboBoxPlaceholderForeground}"
                                    VerticalAlignment="Center"
                                    Margin="{TemplateBinding Padding}"
                                    IsVisible="{Binding SelectedItem, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNull}}" />
@@ -63,8 +63,8 @@
                                Placement="Bottom"
                                IsLightDismissEnabled="True"
                                IsOpen="{TemplateBinding IsDropDownOpen, Mode=TwoWay}">
-                            <Border Background="#2D2D2D"
-                                    BorderBrush="#5D5D5D"
+                            <Border Background="{DynamicResource ComboBoxDropDownBackground}"
+                                    BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
                                     BorderThickness="1"
                                     CornerRadius="4"
                                     MaxHeight="{TemplateBinding MaxDropDownHeight}"
@@ -84,13 +84,21 @@
     </Style>
     
     <!-- PointerOver State -->
+    <Style Selector="controls|ComboBox:pointerover">
+        <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
+    </Style>
+
     <Style Selector="controls|ComboBox:pointerover /template/ Border#Border">
-        <Setter Property="BorderBrush" Value="#7D7D7D" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPointerOver}" />
     </Style>
     
     <!-- Pressed/Focused State -->
+    <Style Selector="controls|ComboBox:focus">
+        <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundFocused}" />
+    </Style>
+
     <Style Selector="controls|ComboBox:focus /template/ Border#Border">
-        <Setter Property="BorderBrush" Value="#0078D4" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushFocused}" />
     </Style>
     
     <!-- DropDown Open - rotate arrow -->
@@ -102,6 +110,9 @@
     
     <!-- Disabled State -->
     <Style Selector="controls|ComboBox:disabled">
+        <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+        <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
         <Setter Property="Opacity" Value="0.5" />
     </Style>
     

--- a/src/CrissCross.WPF.UI.Gallery/App.xaml
+++ b/src/CrissCross.WPF.UI.Gallery/App.xaml
@@ -9,7 +9,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ui:ControlsDictionary />
-                <ui:ThemesDictionary Theme="Dark" />
+                <ui:ThemesDictionary />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/src/CrissCross.WPF.UI.Gallery/ViewModels/FeaturePlaygroundViewModel.cs
+++ b/src/CrissCross.WPF.UI.Gallery/ViewModels/FeaturePlaygroundViewModel.cs
@@ -10,6 +10,8 @@ using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using CrissCross.WPF.UI;
+using CrissCross.WPF.UI.Appearance;
 using ReactiveUI;
 
 namespace CrissCross.WPF.UI.Gallery.ViewModels;
@@ -44,7 +46,7 @@ public sealed class FeaturePlaygroundViewModel : RxObject
         _currentRange = CreateRange(DateTimeOffset.Now);
         _segmentState = new SegmentedSelectionState(CreateSegments(), "table");
         _stepperState = new StepperState(CreateSteps("review"), "review", StepperOrientation.Horizontal);
-        _themeState = new ThemePreferenceState(_selectedTheme, ThemeChoice.Dark, supportsHighContrast: true);
+        _themeState = CreateThemeState(_selectedTheme);
 
         RunImportCommand = ReactiveCommand.CreateFromTask(RunImportAsync);
         SearchCommand = ReactiveCommand.CreateFromTask<string>(SearchAsync);
@@ -208,7 +210,7 @@ public sealed class FeaturePlaygroundViewModel : RxObject
             }
 
             this.RaiseAndSetIfChanged(ref _selectedTheme, value);
-            ThemeState = new ThemePreferenceState(value, ThemeChoice.Dark, supportsHighContrast: true);
+            ThemeState = CreateThemeState(value);
         }
     }
 
@@ -287,6 +289,16 @@ public sealed class FeaturePlaygroundViewModel : RxObject
         new StepDescriptor("review", "Review", currentKey == "review" ? StepStatus.Active : StepStatus.Pending),
         new StepDescriptor("publish", "Publish", StepStatus.Pending, canEnter: currentKey == "review")
     ];
+
+    private static ThemePreferenceState CreateThemeState(ThemeChoice selectedChoice) =>
+        new(selectedChoice, GetSystemThemeChoice(), supportsHighContrast: true);
+
+    private static ThemeChoice GetSystemThemeChoice() => new ThemeService().GetSystemTheme() switch
+    {
+        ApplicationTheme.Dark => ThemeChoice.Dark,
+        ApplicationTheme.HighContrast => ThemeChoice.HighContrast,
+        _ => ThemeChoice.Light
+    };
 
     private async Task RunImportAsync(CancellationToken cancellationToken)
     {

--- a/src/CrissCross.WPF.UI.Gallery/ViewModels/MainViewModel.cs
+++ b/src/CrissCross.WPF.UI.Gallery/ViewModels/MainViewModel.cs
@@ -31,7 +31,7 @@ public partial class MainViewModel : RxObject
                 <ResourceDictionary>
                     <ResourceDictionary.MergedDictionaries>
                         <ui:ControlsDictionary />
-                        <ui:ThemesDictionary Theme="Dark" />
+                        <ui:ThemesDictionary />
                     </ResourceDictionary.MergedDictionaries>
                 </ResourceDictionary>
             </Application.Resources>

--- a/src/CrissCross.WPF.UI.Gallery/Views/AllControlsView.xaml
+++ b/src/CrissCross.WPF.UI.Gallery/Views/AllControlsView.xaml
@@ -55,7 +55,7 @@
                                     <TextBlock FontWeight="SemiBold" Text="{Binding Name}" />
                                     <TextBlock
                                         FontSize="11"
-                                        Foreground="Gray"
+                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                         Text="{Binding Description}"
                                         TextTrimming="CharacterEllipsis" />
                                 </StackPanel>

--- a/src/CrissCross.WPF.UI.Gallery/Views/FeaturePlaygroundView.xaml
+++ b/src/CrissCross.WPF.UI.Gallery/Views/FeaturePlaygroundView.xaml
@@ -25,7 +25,7 @@
                 <Border
                     Margin="0,0,12,12"
                     Padding="16"
-                    BorderBrush="#FFD0D0D0"
+                    BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
                     BorderThickness="1"
                     CornerRadius="8">
                     <StackPanel>
@@ -63,7 +63,7 @@
                 <Border
                     Margin="0,0,0,12"
                     Padding="16"
-                    BorderBrush="#FFD0D0D0"
+                    BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
                     BorderThickness="1"
                     CornerRadius="8">
                     <StackPanel>
@@ -93,7 +93,7 @@
                 <Border
                     Margin="0,0,12,12"
                     Padding="16"
-                    BorderBrush="#FFD0D0D0"
+                    BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
                     BorderThickness="1"
                     CornerRadius="8">
                     <StackPanel>
@@ -116,7 +116,7 @@
                 <Border
                     Margin="0,0,0,12"
                     Padding="16"
-                    BorderBrush="#FFD0D0D0"
+                    BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
                     BorderThickness="1"
                     CornerRadius="8">
                     <StackPanel>
@@ -141,7 +141,7 @@
             <Border
                 Margin="0,8,0,0"
                 Padding="16"
-                BorderBrush="#FFD0D0D0"
+                BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
                 BorderThickness="1"
                 CornerRadius="8">
                 <StackPanel>

--- a/src/CrissCross.WPF.UI.Gallery/Views/MainView.xaml
+++ b/src/CrissCross.WPF.UI.Gallery/Views/MainView.xaml
@@ -54,7 +54,7 @@
             <Border
                 Grid.Row="5"
                 Padding="10"
-                BorderBrush="Black"
+                BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
                 BorderThickness="1">
                 <ui:TextBlock
                     FontSize="14"

--- a/src/CrissCross.WPF.UI/Appearance/ApplicationThemeManager.cs
+++ b/src/CrissCross.WPF.UI/Appearance/ApplicationThemeManager.cs
@@ -33,6 +33,7 @@ public static class ApplicationThemeManager
     internal const string LibraryNamespace = "crisscross.wpf.ui;";
 
     internal const string ThemesDictionaryPath = "pack://application:,,,/CrissCross.WPF.UI;component/Resources/Theme/";
+    private const string ThemeDictionaryLookup = "/resources/theme/";
     private static ApplicationTheme _cachedApplicationTheme = ApplicationTheme.Unknown;
 
     /// <summary>
@@ -98,7 +99,7 @@ public static class ApplicationThemeManager
         }
 
         var isUpdated = appDictionaries.UpdateDictionary(
-            "theme",
+            ThemeDictionaryLookup,
             new Uri(ThemesDictionaryPath + themeDictionaryName + ".xaml", UriKind.Absolute));
 
 #if DEBUG
@@ -279,7 +280,7 @@ public static class ApplicationThemeManager
     private static void FetchApplicationTheme()
     {
         ResourceDictionaryManager appDictionaries = new(LibraryNamespace);
-        var themeDictionary = appDictionaries.GetDictionary("theme");
+        var themeDictionary = appDictionaries.GetDictionary(ThemeDictionaryLookup);
 
         if (themeDictionary == null)
         {

--- a/src/CrissCross.WPF.UI/Controls/ThemeSwitcher/ThemeSwitcher.cs
+++ b/src/CrissCross.WPF.UI/Controls/ThemeSwitcher/ThemeSwitcher.cs
@@ -149,13 +149,15 @@ public class ThemeSwitcher : Control
     /// <param name="choice">The requested theme choice or name.</param>
     public void ApplyChoice(object? choice)
     {
+        var themeService = ThemeService ?? new ThemeService();
         var selectedChoice = ParseChoice(choice);
+        SetCurrentValue(SystemChoiceProperty, ToThemeChoice(themeService.GetSystemTheme()));
         SetCurrentValue(SelectedChoiceProperty, selectedChoice);
 
         var state = CreateState();
         SetCurrentValue(CurrentStateProperty, state);
 
-        ApplyTheme(ThemeService ?? new ThemeService(), selectedChoice, state.EffectiveChoice);
+        ApplyTheme(themeService, selectedChoice, state.EffectiveChoice);
 
         if (ThemeChangedCommand?.CanExecute(selectedChoice) == true)
         {
@@ -194,6 +196,13 @@ public class ThemeSwitcher : Control
         ThemeChoice.Dark => ApplicationTheme.Dark,
         ThemeChoice.HighContrast => ApplicationTheme.HighContrast,
         _ => ApplicationTheme.Light
+    };
+
+    private static ThemeChoice ToThemeChoice(ApplicationTheme theme) => theme switch
+    {
+        ApplicationTheme.Dark => ThemeChoice.Dark,
+        ApplicationTheme.HighContrast => ThemeChoice.HighContrast,
+        _ => ThemeChoice.Light
     };
 
     private sealed class ThemeSwitcherCommand : ICommand

--- a/src/CrissCross.WPF.UI/Markup/ThemesDictionary.cs
+++ b/src/CrissCross.WPF.UI/Markup/ThemesDictionary.cs
@@ -31,7 +31,7 @@ public class ThemesDictionary : ResourceDictionary
     /// <summary>
     /// Initializes a new instance of the <see cref="ThemesDictionary"/> class.
     /// </summary>
-    public ThemesDictionary() => SetSourceBasedOnSelectedTheme(ApplicationTheme.Dark);
+    public ThemesDictionary() => SetSourceBasedOnSelectedTheme(GetSystemApplicationTheme());
 
     /// <summary>
     /// Sets the default application theme.
@@ -40,6 +40,13 @@ public class ThemesDictionary : ResourceDictionary
     {
         set => SetSourceBasedOnSelectedTheme(value);
     }
+
+    private static ApplicationTheme GetSystemApplicationTheme() => ApplicationThemeManager.GetSystemTheme() switch
+    {
+        SystemTheme.Dark or SystemTheme.Glow or SystemTheme.CapturedMotion => ApplicationTheme.Dark,
+        SystemTheme.HCBlack or SystemTheme.HC1 or SystemTheme.HC2 or SystemTheme.HCWhite => ApplicationTheme.HighContrast,
+        _ => ApplicationTheme.Light
+    };
 
     private void SetSourceBasedOnSelectedTheme(ApplicationTheme? selectedApplicationTheme)
     {


### PR DESCRIPTION
Use system theme detection and unify theme handling across WPF and Avalonia. 
ThemeSwitcher now uses ThemeService and maps ApplicationTheme -> ThemeChoice; FeaturePlayground viewmodels build ThemePreferenceState from the system theme. 
ThemesDictionary now initializes from the system application theme and ApplicationThemeManager fixes the theme dictionary lookup path. 
Add missing ComboBox and Navigation brushes to Light/Dark theme resources and update ComboBox theme to use DynamicResource values. 
Replace many hardcoded colors in XAML and code-behind with resource brushes, add gallery style classes in the Avalonia MainWindow, and remove explicit Theme="Dark" resource usage in gallery app resources.